### PR TITLE
Fix: Handle JSON encoding errors in returnError method

### DIFF
--- a/jwt_claims_headers.go
+++ b/jwt_claims_headers.go
@@ -171,5 +171,7 @@ func (j *JWTClaimsHeaders) returnError(rw http.ResponseWriter, errorType, messag
 		"message": message,
 	}
 
-	json.NewEncoder(rw).Encode(errorResponse)
+	if err := json.NewEncoder(rw).Encode(errorResponse); err != nil {
+		log.Printf("[%s] Failed to encode error response: %v", j.name, err)
+	}
 }


### PR DESCRIPTION
## Summary
Fixes #1

The `returnError()` method now properly handles JSON encoding errors instead of silently ignoring them.

## Changes
- Added error handling for `json.NewEncoder().Encode()` in `jwt_claims_headers.go:174`
- Log encoding failures with plugin context for easier debugging

## Before
```go
json.NewEncoder(rw).Encode(errorResponse)
```

## After
```go
if err := json.NewEncoder(rw).Encode(errorResponse); err != nil {
    log.Printf("[%s] Failed to encode error response: %v", j.name, err)
}
```

## Impact
- Prevents silent failures when JSON encoding errors occur
- Makes debugging easier in production environments
- Improves error visibility for operators

## Testing
- ✅ All existing tests pass
- ✅ No changes to test suite required (error handling is defensive)

## Type
- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>