### PR TITLE
Fix: Update module path from placeholder to actual repository

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -1,6 +1,6 @@
 displayName: JWT Claims to Headers
 type: middleware
-import: github.com/user/traefik-jwt-decoder-plugin
+import: github.com/jander99/traefik-jwt-decoder-plugin
 summary: Extract JWT claims and inject as HTTP headers
 
 testData:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/user/traefik-jwt-decoder-plugin
+module github.com/jander99/traefik-jwt-decoder-plugin
 
 go 1.21


### PR DESCRIPTION
## Summary
Fixes #2

Updated the module path from placeholder `github.com/user/` to the actual repository path `github.com/jander99/`.

## Changes
- ✅ Updated `go.mod` module declaration (line 1)
- ✅ Updated `.traefik.yml` import path (line 3)

## Before
```go
module github.com/user/traefik-jwt-decoder-plugin
```

## After
```go
module github.com/jander99/traefik-jwt-decoder-plugin
```

## Impact
**🚨 Release Blocker**: The plugin cannot be imported or loaded by Traefik without the correct module path. This fix is required before any publication or distribution.

## Testing
- ✅ `go mod tidy` runs without errors
- ✅ All tests pass with new module path
- ✅ Module path matches repository structure

## Type
- [x] Bug fix (non-breaking change)
- [x] Release blocker
- [ ] Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>