### PR TITLE
Feature: Add optional JWT header validation (strict mode)

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,6 +41,10 @@ type Config struct {
 	// MaxHeaderSize is the maximum size of header values in bytes (default: 8192)
 	// Prevents memory exhaustion attacks
 	MaxHeaderSize int `json:"maxHeaderSize,omitempty" yaml:"maxHeaderSize,omitempty"`
+
+	// StrictMode validates JWT header structure (requires 'alg' field) (default: false)
+	// Set to true for enhanced security validation, false for backward compatibility
+	StrictMode bool `json:"strictMode,omitempty" yaml:"strictMode,omitempty"`
 }
 
 // ClaimMapping defines a single mapping from a JWT claim path to an HTTP header name.
@@ -76,6 +80,7 @@ func CreateConfig() *Config {
 		RemoveSourceHeader: false,
 		MaxClaimDepth:      10,
 		MaxHeaderSize:      8192,
+		StrictMode:         false,
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -376,4 +376,46 @@ func TestCreateConfig(t *testing.T) {
 	if config.MaxHeaderSize != 8192 {
 		t.Errorf("Default MaxHeaderSize = %d, want 8192", config.MaxHeaderSize)
 	}
+	if config.StrictMode {
+		t.Errorf("Default StrictMode = %v, want false", config.StrictMode)
+	}
+}
+
+// TestValidate_StrictMode verifies StrictMode field validates correctly
+func TestValidate_StrictMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		strictMode bool
+		wantErr    bool
+	}{
+		{
+			name:       "StrictMode true",
+			strictMode: true,
+			wantErr:    false,
+		},
+		{
+			name:       "StrictMode false",
+			strictMode: false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				Claims: []ClaimMapping{
+					{ClaimPath: "sub", HeaderName: "X-User-Id"},
+				},
+				Sections:      []string{"payload"},
+				MaxClaimDepth: 10,
+				MaxHeaderSize: 8192,
+				StrictMode:    tt.strictMode,
+			}
+
+			err := config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/jwt_claims_headers.go
+++ b/jwt_claims_headers.go
@@ -84,7 +84,7 @@ func (j *JWTClaimsHeaders) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 	token := ExtractToken(headerValue, j.config.TokenPrefix)
 
 	// 3. Parse JWT
-	jwt, err := ParseJWT(token)
+	jwt, err := ParseJWT(token, j.config.StrictMode)
 	if err != nil {
 		log.Printf("[%s] JWT parse error: %v", j.name, err)
 		if j.config.ContinueOnError {


### PR DESCRIPTION
## Summary
Fixes #4

Added `StrictMode` configuration option to validate JWT header structure. When enabled, validates that the JWT header contains the required `alg` field, helping detect malformed tokens that might indicate attacks or misconfigurations.

## Changes
- ✅ Added `StrictMode` field to `Config` struct (default: `false`)
- ✅ Updated `ParseJWT()` function to accept and validate strictMode parameter
- ✅ Added JWT header validation for required 'alg' field
- ✅ Updated all test calls to include strictMode parameter
- ✅ Added comprehensive tests for strict mode validation
- ✅ Updated `CreateConfig()` with default value

## Configuration Example

```yaml
# Traefik dynamic configuration
http:
  middlewares:
    jwt-decoder:
      plugin:
        traefik-jwt-decoder-plugin:
          sourceHeader: Authorization
          strictMode: true  # Enable enhanced security validation
          claims:
            - claimPath: sub
              headerName: X-User-Id
```

## Behavior

### Standard Mode (default: `strictMode: false`)
```go
// Accepts any valid JWT structure
// {"typ":"JWT"}.{"sub":"123"}.signature  ✅ Valid
// {}.{"sub":"123"}.signature             ✅ Valid
// {"alg":"HS256"}.{"sub":"123"}.sig      ✅ Valid
```

### Strict Mode (`strictMode: true`)
```go
// Requires 'alg' field in JWT header
// {"alg":"HS256","typ":"JWT"}.{"sub":"123"}.sig  ✅ Valid
// {"typ":"JWT"}.{"sub":"123"}.signature          ❌ Error: missing required 'alg' field
// {}.{"sub":"123"}.signature                     ❌ Error: missing required 'alg' field
```

## Security Benefits
- **Early Detection**: Catch malformed JWTs before claim extraction
- **Attack Prevention**: Detect tokens that might indicate manipulation attempts
- **Misconfiguration Detection**: Identify authentication system issues
- **RFC Compliance**: Enforce JWT standard requirements (RFC 7519)

## Impact
**Backward Compatible**: Default behavior unchanged (`strictMode: false`)
**Opt-In Security**: Users can enable strict validation per deployment

## Testing
- ✅ All existing tests pass
- ✅ New test validates 'alg' field presence in strict mode
- ✅ New test validates tokens without 'alg' fail in strict mode
- ✅ New test validates backward compatibility (strict mode disabled)
- ✅ Config test validates StrictMode field

## Type
- [ ] Bug fix
- [x] New feature (non-breaking change)
- [ ] Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>