### PR TITLE
feat: add configurable log levels (fixes #5)

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,6 +41,14 @@ type Config struct {
 	// MaxHeaderSize is the maximum size of header values in bytes (default: 8192)
 	// Prevents memory exhaustion attacks
 	MaxHeaderSize int `json:"maxHeaderSize,omitempty" yaml:"maxHeaderSize,omitempty"`
+
+	// LogLevel controls logging verbosity (default: "warn")
+	// Valid values: "debug", "info", "warn", "error"
+	//   - "debug": Log all operations including header injections
+	//   - "info": Log significant operations
+	//   - "warn": Log warnings and errors only (production default)
+	//   - "error": Log errors only
+	LogLevel string `json:"logLevel,omitempty" yaml:"logLevel,omitempty"`
 }
 
 // ClaimMapping defines a single mapping from a JWT claim path to an HTTP header name.
@@ -76,6 +84,7 @@ func CreateConfig() *Config {
 		RemoveSourceHeader: false,
 		MaxClaimDepth:      10,
 		MaxHeaderSize:      8192,
+		LogLevel:           "warn",
 	}
 }
 
@@ -147,6 +156,19 @@ func (c *Config) Validate() error {
 	// Check MaxHeaderSize > 0
 	if c.MaxHeaderSize <= 0 {
 		return fmt.Errorf("maxHeaderSize must be greater than 0")
+	}
+
+	// Validate LogLevel if provided
+	if c.LogLevel != "" {
+		validLevels := map[string]bool{
+			"debug": true,
+			"info":  true,
+			"warn":  true,
+			"error": true,
+		}
+		if !validLevels[c.LogLevel] {
+			return fmt.Errorf("invalid logLevel '%s', must be 'debug', 'info', 'warn', or 'error'", c.LogLevel)
+		}
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -376,4 +376,76 @@ func TestCreateConfig(t *testing.T) {
 	if config.MaxHeaderSize != 8192 {
 		t.Errorf("Default MaxHeaderSize = %d, want 8192", config.MaxHeaderSize)
 	}
+	if config.LogLevel != "warn" {
+		t.Errorf("Default LogLevel = %q, want \"warn\"", config.LogLevel)
+	}
+}
+
+// TestValidate_LogLevel verifies LogLevel field validation
+func TestValidate_LogLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		logLevel string
+		wantErr  bool
+	}{
+		{
+			name:     "debug level valid",
+			logLevel: "debug",
+			wantErr:  false,
+		},
+		{
+			name:     "info level valid",
+			logLevel: "info",
+			wantErr:  false,
+		},
+		{
+			name:     "warn level valid",
+			logLevel: "warn",
+			wantErr:  false,
+		},
+		{
+			name:     "error level valid",
+			logLevel: "error",
+			wantErr:  false,
+		},
+		{
+			name:     "empty string valid (uses default)",
+			logLevel: "",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid level uppercase",
+			logLevel: "DEBUG",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid level",
+			logLevel: "invalid",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid level trace",
+			logLevel: "trace",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				Claims: []ClaimMapping{
+					{ClaimPath: "sub", HeaderName: "X-User-Id"},
+				},
+				Sections:      []string{"payload"},
+				MaxClaimDepth: 10,
+				MaxHeaderSize: 8192,
+				LogLevel:      tt.logLevel,
+			}
+
+			err := config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/jwt_claims_headers.go
+++ b/jwt_claims_headers.go
@@ -22,6 +22,24 @@ type JWTClaimsHeaders struct {
 	name string
 }
 
+// shouldLog determines if a message at the given level should be logged
+// based on the configured log level.
+//
+// Log level hierarchy: debug < info < warn < error
+func (j *JWTClaimsHeaders) shouldLog(level string) bool {
+	levels := map[string]int{
+		"debug": 0,
+		"info":  1,
+		"warn":  2,
+		"error": 3,
+	}
+
+	configLevel := levels[j.config.LogLevel]
+	messageLevel := levels[level]
+
+	return messageLevel >= configLevel
+}
+
 // New creates a new JWTClaimsHeaders plugin instance.
 // This function is called by Traefik during plugin initialization.
 //
@@ -71,7 +89,9 @@ func (j *JWTClaimsHeaders) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 	// 1. Extract JWT from source header
 	headerValue := req.Header.Get(j.config.SourceHeader)
 	if headerValue == "" {
-		log.Printf("[%s] JWT source header not found: %s", j.name, j.config.SourceHeader)
+		if j.shouldLog("warn") {
+			log.Printf("[%s] JWT source header not found: %s", j.name, j.config.SourceHeader)
+		}
 		if j.config.ContinueOnError {
 			j.next.ServeHTTP(rw, req)
 			return
@@ -86,7 +106,9 @@ func (j *JWTClaimsHeaders) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 	// 3. Parse JWT
 	jwt, err := ParseJWT(token)
 	if err != nil {
-		log.Printf("[%s] JWT parse error: %v", j.name, err)
+		if j.shouldLog("error") {
+			log.Printf("[%s] JWT parse error: %v", j.name, err)
+		}
 		if j.config.ContinueOnError {
 			j.next.ServeHTTP(rw, req)
 			return
@@ -119,25 +141,33 @@ func (j *JWTClaimsHeaders) ServeHTTP(rw http.ResponseWriter, req *http.Request) 
 		}
 
 		if !found {
-			log.Printf("[%s] Claim not found: %s", j.name, claimMapping.ClaimPath)
+			if j.shouldLog("warn") {
+				log.Printf("[%s] Claim not found: %s", j.name, claimMapping.ClaimPath)
+			}
 			continue // Skip this mapping
 		}
 
 		// Convert claim to string
 		strValue, err := ConvertClaimToString(claimValue, claimMapping.ArrayFormat)
 		if err != nil {
-			log.Printf("[%s] Failed to convert claim %s: %v", j.name, claimMapping.ClaimPath, err)
+			if j.shouldLog("error") {
+				log.Printf("[%s] Failed to convert claim %s: %v", j.name, claimMapping.ClaimPath, err)
+			}
 			continue
 		}
 
 		// Inject header
 		err = InjectHeader(req, claimMapping.HeaderName, strValue, claimMapping.Override, j.config.MaxHeaderSize)
 		if err != nil {
-			log.Printf("[%s] Failed to inject header %s: %v", j.name, claimMapping.HeaderName, err)
+			if j.shouldLog("error") {
+				log.Printf("[%s] Failed to inject header %s: %v", j.name, claimMapping.HeaderName, err)
+			}
 			continue
 		}
 
-		log.Printf("[%s] Injected header: %s = %s", j.name, claimMapping.HeaderName, strValue)
+		if j.shouldLog("debug") {
+			log.Printf("[%s] Injected header: %s = %s", j.name, claimMapping.HeaderName, strValue)
+		}
 	}
 
 	// 5. Remove source header if configured


### PR DESCRIPTION
## Summary
Adds configurable log levels to control logging verbosity in production deployments.

## Changes
- ✅ Add `LogLevel` field to `Config` struct (default: `"warn"`)
- ✅ Implement `shouldLog()` method with log level hierarchy: `debug < info < warn < error`
- ✅ Move header injection logging to `"debug"` level (was unconditional)
- ✅ Keep error logs at `"error"` level
- ✅ Keep warnings at `"warn"` level
- ✅ Add `LogLevel` validation in `Config.Validate()`
- ✅ Add comprehensive tests for `LogLevel` validation

## Benefits
- **Reduces production log volume**: With default `"warn"` level, header injection logs are suppressed
- **Maintains observability**: Errors and warnings still logged by default
- **Flexible debugging**: Users can enable verbose logging with `logLevel: "debug"` when needed
- **Performance**: Reduces I/O overhead in high-traffic scenarios

## Impact Analysis
- At 1000 req/s with 3 claims per request: **Saves ~259M log lines per day**
- No breaking changes: Default behavior is production-ready
- Backward compatible: Existing configs work without modification

## Configuration Example
```yaml
# Production (default)
logLevel: "warn"  # Only warnings and errors

# Development
logLevel: "debug"  # All operations including header injections

# Minimal
logLevel: "error"  # Only errors
```

## Testing
- ✅ All existing tests pass
- ✅ Added `TestValidate_LogLevel` with 8 test cases
- ✅ Updated `TestCreateConfig` to verify default value
- ✅ Verified log level hierarchy behavior

## Fixes
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)